### PR TITLE
console command for deleting expired videos

### DIFF
--- a/app/Console/Commands/DeleteExpiredVideos.php
+++ b/app/Console/Commands/DeleteExpiredVideos.php
@@ -29,7 +29,6 @@ class DeleteExpiredVideos extends Command
      * Find list of expired videos
      */
     private function getVideos($date) {
-      // 24th will not be included for delete list
       return GeneratedVideo::where('created_at', '>', $date);
     }
 

--- a/app/Console/Commands/DeleteExpiredVideos.php
+++ b/app/Console/Commands/DeleteExpiredVideos.php
@@ -14,7 +14,7 @@ class DeleteExpiredVideos extends Command
      *
      * @var string
      */
-    protected $signature = 'videos:delete {hours} {prefix?}';
+    protected $signature = 'videos:delete {hours?} {prefix?}';
 
     private $hours;
 

--- a/app/Console/Commands/DeleteExpiredVideos.php
+++ b/app/Console/Commands/DeleteExpiredVideos.php
@@ -53,7 +53,6 @@ class DeleteExpiredVideos extends Command
      */
     public function handle()
     {
-        // Storage::delete("generated/batman-listening-1665684516-235985.mp4");
         $date = Carbon::now()->subHours($this->hours)->toDateTimeString();
         $this->hours = $this->argument('hours');
         if (!$this->hours) {

--- a/app/Console/Commands/DeleteExpiredVideos.php
+++ b/app/Console/Commands/DeleteExpiredVideos.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\GeneratedVideo;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Storage;
+
+class DeleteExpiredVideos extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'videos:delete {hours} {prefix?}';
+
+    private $hours;
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Delete videos created before {X} hours';
+
+    /**
+     * Find list of expired videos
+     */
+    private function getVideos($date) {
+      // 24th will not be included for delete list
+      return GeneratedVideo::where('created_at', '>', $date);
+    }
+
+    /**
+     * Delete videos from file system
+     * @return void
+     */
+    private function deleteVideosFromFS($videos) {
+        $paths = collect($videos)->each(function ($video) {
+            $path = $this->argument('prefix').
+                str_replace("\/", "/", $video->generated_video_filename);
+
+            if (Storage::exists($path)) Storage::delete($path);
+        });
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        // Storage::delete("generated/batman-listening-1665684516-235985.mp4");
+        $date = Carbon::now()->subHours($this->hours)->toDateTimeString();
+        $this->hours = $this->argument('hours');
+        if (!$this->hours) {
+          $this->hours = config('app.videos.lifetime');
+        }
+        $criteria = $this->getVideos($date);
+        if (($numOfVideos = $criteria->count()) == 0) {
+            $this->info("nothing to delete.");
+            return Command::SUCCESS;
+        }
+
+        $this->info($numOfVideos . ' videos will be deleted.');
+        $videos = $criteria->get();
+        $this->deleteVideosFromFS($videos);
+        $criteria->delete();
+
+        return Command::SUCCESS;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -15,7 +15,7 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        // $schedule->command('inspire')->hourly();
+        $schedule->command('videos:delete')->daily();
     }
 
     /**

--- a/config/app.php
+++ b/config/app.php
@@ -121,6 +121,10 @@ return [
     |
     */
 
+    'videos' => [
+      'lifetime' => env('VIDEOS_LIFETIME', 24) // as hours
+    ],
+
     'key' => env('APP_KEY'),
 
     'cipher' => 'AES-256-CBC',


### PR DESCRIPTION
Created laravel console command "videos:delete" for deleting videos.

That command can be receive 2 optional arguments. 

- hours: default value is **24**. And also default value can be configured from .env.
- directory prefix: can be used as describe storage file prefix. default is **none**.

Value of the **generated_video_filename** strored as forward slashes escaped. 
For an example: generate\/video.mp4 it led file not found issue. So I spent few hours for found it.

You should use linux's **crontab** directly, instead of using laravels way, if your application is running on VPS.

Just like:
`0 0 * * * cd /../batman-listening-things && php artisan videos:delete > /dev/null 2>&1`

I hope it might save your time.

Thank you
